### PR TITLE
feat(Account): implement Account.find_by_tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,4 +40,4 @@ end
 gem 'validates_timeliness'
 gem 'has_vcards'
 # Tagging
-gem 'acts-as-taggable-on'
+gem 'acts-as-taggable-on', '~> 2.4.1' # API incompatible

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,8 +31,8 @@ GEM
     activesupport (3.2.22)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
-    acts-as-taggable-on (3.5.0)
-      activerecord (>= 3.2, < 5)
+    acts-as-taggable-on (2.4.1)
+      rails (>= 3, < 5)
     arel (3.0.3)
     builder (3.0.4)
     byebug (4.0.5)
@@ -171,7 +171,7 @@ PLATFORMS
 
 DEPENDENCIES
   accept_values_for
-  acts-as-taggable-on
+  acts-as-taggable-on (~> 2.4.1)
   factory_girl_rails (~> 1.1)
   has_vcards
   mysql2

--- a/spec/dummy/db/migrate/20120119222109_acts_as_taggable_on_migration.rb
+++ b/spec/dummy/db/migrate/20120119222109_acts_as_taggable_on_migration.rb
@@ -1,0 +1,28 @@
+class ActsAsTaggableOnMigration < ActiveRecord::Migration
+  def self.up
+    create_table :tags do |t|
+      t.string :name
+    end
+
+    create_table :taggings do |t|
+      t.references :tag
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, :polymorphic => true
+      t.references :tagger, :polymorphic => true
+
+      t.string :context
+
+      t.datetime :created_at
+    end
+
+    add_index :taggings, :tag_id
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    drop_table :taggings
+    drop_table :tags
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,92 +11,119 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_131_105_212_025) do
-  create_table 'account_types', force: true do |t|
-    t.string 'name',       limit: 100
-    t.string 'title',      limit: 100
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
+ActiveRecord::Schema.define(:version => 20131105212025) do
+
+  create_table "account_types", :force => true do |t|
+    t.string   "name",       :limit => 100
+    t.string   "title",      :limit => 100
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  add_index 'account_types', ['name'], name: 'index_account_types_on_name'
+  add_index "account_types", ["name"], :name => "index_account_types_on_name"
 
-  create_table 'accounts', force: true do |t|
-    t.string 'title',           limit: 100
-    t.integer 'parent_id'
-    t.integer 'account_type_id'
-    t.string 'number'
-    t.string 'code'
-    t.string 'type'
-    t.integer 'holder_id'
-    t.string 'holder_type'
-    t.integer 'bank_id'
-    t.integer 'esr_id'
-    t.string 'pc_id'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
-    t.string 'iban'
+  create_table "accounts", :force => true do |t|
+    t.string   "title",           :limit => 100
+    t.integer  "parent_id"
+    t.integer  "account_type_id"
+    t.string   "number"
+    t.string   "code"
+    t.string   "type"
+    t.integer  "holder_id"
+    t.string   "holder_type"
+    t.integer  "bank_id"
+    t.integer  "esr_id"
+    t.string   "pc_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "iban"
   end
 
-  add_index 'accounts', ['account_type_id'], name: 'index_accounts_on_account_type_id'
-  add_index 'accounts', ['bank_id'], name: 'index_accounts_on_bank_id'
-  add_index 'accounts', ['code'], name: 'index_accounts_on_code'
-  add_index 'accounts', %w(holder_id holder_type), name: 'index_accounts_on_holder_id_and_holder_type'
-  add_index 'accounts', ['parent_id'], name: 'index_accounts_on_parent_id'
-  add_index 'accounts', ['type'], name: 'index_accounts_on_type'
+  add_index "accounts", ["account_type_id"], :name => "index_accounts_on_account_type_id"
+  add_index "accounts", ["bank_id"], :name => "index_accounts_on_bank_id"
+  add_index "accounts", ["code"], :name => "index_accounts_on_code"
+  add_index "accounts", ["holder_id", "holder_type"], :name => "index_accounts_on_holder_id_and_holder_type"
+  add_index "accounts", ["parent_id"], :name => "index_accounts_on_parent_id"
+  add_index "accounts", ["type"], :name => "index_accounts_on_type"
 
-  create_table 'booking_templates', force: true do |t|
-    t.string 'title'
-    t.string 'amount'
-    t.integer 'credit_account_id'
-    t.integer 'debit_account_id'
-    t.text 'comments'
-    t.datetime 'created_at',              null: false
-    t.datetime 'updated_at',              null: false
-    t.string 'code'
-    t.string 'matcher'
-    t.string 'amount_relates_to'
-    t.string 'type'
-    t.string 'charge_rate_code'
-    t.string 'salary_declaration_code'
-    t.integer 'position'
+  create_table "banks", :force => true do |t|
+    t.integer  "vcard_id"
+    t.string   "swift"
+    t.string   "clearing"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  create_table 'bookings', force: true do |t|
-    t.string 'title',             limit: 100
-    t.decimal 'amount',                            precision: 10, scale: 2
-    t.integer 'credit_account_id'
-    t.integer 'debit_account_id'
-    t.date 'value_date'
-    t.text 'comments',          limit: 1000,                                default: ''
-    t.string 'scan'
-    t.string 'debit_currency',                                                   default: 'CHF'
-    t.string 'credit_currency',                                                  default: 'CHF'
-    t.float 'exchange_rate',                                                    default: 1.0
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
-    t.integer 'reference_id'
-    t.string 'reference_type'
-    t.integer 'template_id'
-    t.string 'template_type'
+  add_index "banks", ["vcard_id"], :name => "index_banks_on_vcard_id"
+
+  create_table "booking_templates", :force => true do |t|
+    t.string   "title"
+    t.string   "amount"
+    t.integer  "credit_account_id"
+    t.integer  "debit_account_id"
+    t.text     "comments"
+    t.datetime "created_at",              :null => false
+    t.datetime "updated_at",              :null => false
+    t.string   "code"
+    t.string   "matcher"
+    t.string   "amount_relates_to"
+    t.string   "type"
+    t.string   "charge_rate_code"
+    t.string   "salary_declaration_code"
+    t.integer  "position"
   end
 
-  add_index 'bookings', ['credit_account_id'], name: 'index_bookings_on_credit_account_id'
-  add_index 'bookings', ['debit_account_id'], name: 'index_bookings_on_debit_account_id'
-  add_index 'bookings', %w(reference_id reference_type), name: 'index_bookings_on_reference_id_and_reference_type'
-  add_index 'bookings', %w(template_id template_type), name: 'index_bookings_on_template_id_and_template_type'
-  add_index 'bookings', ['value_date'], name: 'index_bookings_on_value_date'
-
-  create_table 'invoices', force: true do |t|
-    t.date 'value_date'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "bookings", :force => true do |t|
+    t.string   "title",             :limit => 100
+    t.decimal  "amount",                           :precision => 10, :scale => 2
+    t.integer  "credit_account_id"
+    t.integer  "debit_account_id"
+    t.date     "value_date"
+    t.text     "comments"
+    t.string   "scan"
+    t.string   "debit_currency",                                                  :default => "CHF"
+    t.string   "credit_currency",                                                 :default => "CHF"
+    t.float    "exchange_rate",                                                   :default => 1.0
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer  "reference_id"
+    t.string   "reference_type"
+    t.integer  "template_id"
+    t.string   "template_type"
   end
 
-  create_table 'people', force: true do |t|
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.string 'swift'
-    t.string 'clearing'
+  add_index "bookings", ["credit_account_id"], :name => "index_bookings_on_credit_account_id"
+  add_index "bookings", ["debit_account_id"], :name => "index_bookings_on_debit_account_id"
+  add_index "bookings", ["reference_id", "reference_type"], :name => "index_bookings_on_reference_id_and_reference_type"
+  add_index "bookings", ["template_id", "template_type"], :name => "index_bookings_on_template_id_and_template_type"
+  add_index "bookings", ["value_date"], :name => "index_bookings_on_value_date"
+
+  create_table "invoices", :force => true do |t|
+    t.date     "value_date"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
   end
+
+  create_table "people", :force => true do |t|
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
+
+  create_table "taggings", :force => true do |t|
+    t.integer  "tag_id"
+    t.integer  "taggable_id"
+    t.string   "taggable_type"
+    t.integer  "tagger_id"
+    t.string   "tagger_type"
+    t.string   "context"
+    t.datetime "created_at"
+  end
+
+  add_index "taggings", ["tag_id"], :name => "index_taggings_on_tag_id"
+  add_index "taggings", ["taggable_id", "taggable_type", "context"], :name => "index_taggings_on_taggable_id_and_taggable_type_and_context"
+
+  create_table "tags", :force => true do |t|
+    t.string "name"
+  end
+
 end

--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -1,9 +1,17 @@
 FactoryGirl.define do
+  sequence :account_code do |n|
+    "9%03i" % n
+  end
+end
+
+FactoryGirl.define do
   factory :account do
-    code '0000'
+    code { FactoryGirl.generate(:account_code) }
     title 'Test Account'
     association :account_type
-    initialize_with { Account.where(code: code).first || Account.create(code: code) }
+    initialize_with do
+      Account.where(code: code).first || Account.create(code: code)
+    end
 
     factory :accounts_payable, parent: :account do
       code '2000'

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -30,4 +30,25 @@ describe Account do
       expect(account.unbalanced_references).to eq('result')
     end
   end
+
+  context 'with tagging support' do
+    describe '.find_by_tag' do
+      let!(:account) { FactoryGirl.create(:account, tag_list: tag) }
+      let(:tag) { 'asd:123' }
+
+      context 'one account found with this tag' do
+        specify { expect(Account.find_by_tag(tag)).to eq(account) }
+      end
+
+      context 'multiple accounts found with this tag' do
+        before do
+          FactoryGirl.create(:account, tag_list: tag)
+        end
+
+        it 'raises Account::AmbiguousTag' do
+          expect { Account.find_by_tag(tag) }.to raise_error(Account::AmbiguousTag)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
We support looking up Accounts by tags when the acts-as-taggable-on gem
is used. Looking up by tags might lead to multiple findings, which is
not always what we want. When needing a single instance, as when
assigning to a Booking, you may use the `.find_by_tag` method which
raises an `Account::AmbiguousTag` error if multiple Accounts are
candidates.

Thanks go to luxflux for implementing this while working on API support
for Bookyt: huerlisi/bookyt#82